### PR TITLE
Fix `attenuation_color` read from glTF.

### DIFF
--- a/src/materialxgltf/core.py
+++ b/src/materialxgltf/core.py
@@ -785,9 +785,8 @@ class GLTF2MtlxReader:
                     # Untextured attenuation color
                     if 'attenuationColor' in volumeExtension:
                         attenuationColor = volumeExtension['attenuationColor']
-                        attenuationColor = str(attenuationColor)
                         attenuationInput = shaderNode.addInputFromNodeDef('attenuation_color')
-                        attenuationInput.setValueString(attenuationColor)                    
+                        attenuationInput.setValue(mx.Color3(attenuationColor[0], attenuationColor[1], attenuationColor[2]))
 
                     # Untextured attenuation distance
                     if 'attenuationDistance' in volumeExtension:


### PR DESCRIPTION
## Issue

Was setting string color value = `[v1, v2 v3]` instead of `v1, v2, v3` on input when reading glTF.

## Fix

Create a Color3 and set that as value.

