### PR TITLE
Fix sheen color texture input (glTF -> mtlx)

### DIFF
--- a/src/materialxgltf/core.py
+++ b/src/materialxgltf/core.py
@@ -866,7 +866,7 @@ class GLTF2MtlxReader:
                     sheenColorFactor = sheenColorTexture = None
                     if 'sheenColorFactor' in sheen:
                         sheenColorFactor = sheen['sheenColorFactor']
-                    if 'specularTexture' in sheen:
+                    if 'sheenColorTexture' in sheen:
                         sheenColorTexture = sheen['sheenColorTexture']
                     if sheenColorFactor or sheenColorTexture:
                         self.readColorInput(doc, sheenColorTexture, sheenColorFactor, 'image_sheen',


### PR DESCRIPTION
## Issue
Sheen color texture not picked up on glTF to MTLX load.

## Fix
Fix typo on import so that sheen color texture is picked up properly.

## Example
- QuiltiX example "black upholstery" (JSON)
```json
{
  "materials": [
    {
      "extensions": {
        "KHR_materials_transmission": {
          "transmissionFactor": 0.0
        },
        "KHR_materials_specular": {
          "specularColorFactor": [
            1.0,
            1.0,
            1.0
          ],
          "specularFactor": 1.0
        },
        "KHR_materials_emissive_strength": {
          "emissiveStrength": 1.0
        },
        "KHR_materials_ior": {
          "ior": 1.5
        },
        "KHR_materials_sheen": {
          "sheenColorTexture": {
            "index": 1
          },
          "sheenColorFactor": [
            1.0,
            1.0,
            1.0
          ],
          "sheenRoughnessFactor": 0.49803900718688965
        },
        "KHR_materials_clearcoat": {
          "clearcoatFactor": 0.0,
          "clearcoatRoughnessFactor": 0.09803920239210129
        },
        "KHR_materials_volume": {
          "attenuationColor": [
            1.0,
            1.0,
            1.0
          ]
        },
        "KHR_materials_iridescence": {
          "iridescenceFactor": 0.0,
          "iridescenceIor": 1.2999999523162842
        }
      },
      "name": "standard_surface_1_baked",
      "pbrMetallicRoughness": {
        "baseColorFactor": [
          0.0,
          0.0,
          0.0,
          1.0
        ],
        "metallicFactor": 0.0,
        "roughnessFactor": 1.0,
        "metallicRoughnessTexture": {
          "index": 0
        }
      },
      "emissiveFactor": [
        0.0,
        0.0,
        0.0
      ],
      "alphaMode": "OPAQUE"
    }
  ], 
  "textures": [
    {
      "name": "NG_baked/roughness_baked",
      "source": 0,
      "sampler": 0
    },
    {
      "name": "NG_baked/sheen_color_baked",
      "source": 1,
      "sampler": 0
    }
  ],
  "images": [
    {
      "name": "NG_baked/roughness_baked",
      "uri": "Black_Upholstery_gltf_pbr_roughness_combined.png"
    },
    {
      "name": "NG_baked/sheen_color_baked",
      "uri": "Black_Upholstery_gltf_pbr_sheen_color.png"
    }
  ],
  "samplers": [
    {
      "wrapS": 10497,
      "wrapT": 10497,
      "magFilter": 9729,
      "minFilter": 9986
    }
  ],
  "extensionsUsed": [
    "KHR_materials_transmission",
    "KHR_materials_specular",
    "KHR_materials_emissive_strength",
    "KHR_materials_ior",
    "KHR_materials_sheen",
    "KHR_materials_clearcoat",
    "KHR_materials_volume",
    "KHR_materials_iridescence"
  ]
```

### MaterialX Viewer  (MTLX)
![image](https://github.com/kwokcb/materialxgltf/assets/49369885/7c420d38-92ff-4552-b483-d4912e0a5f0b)

## model-viewer (glTF)
![image](https://github.com/kwokcb/materialxgltf/assets/49369885/7fffd214-17c3-4ccd-91ee-4c21f2ad886a)

